### PR TITLE
Bugfix/remocao-mascara-telefones

### DIFF
--- a/src/main/resources/db/common/V3.13__Remove_Phone_Masks.sql
+++ b/src/main/resources/db/common/V3.13__Remove_Phone_Masks.sql
@@ -1,0 +1,17 @@
+-- Migration V3.13 - Remover máscaras de telefones
+--
+-- OBJETIVO: Remover caracteres especiais (parênteses, hífens, espaços) dos números de telefone
+-- armazenados na tabela fornecedor, mantendo apenas os dígitos numéricos.
+--
+-- EXEMPLO:
+--   Antes: (41) 3123-4567, (41)98765-4321, 41 3123 4567
+--   Depois: 4131234567, 41987654321, 4131234567
+
+-- Atualizar telefones do fornecedor removendo caracteres não-numéricos
+UPDATE fornecedor
+SET telefone = REGEXP_REPLACE(telefone, '[^0-9]', '', 'g')
+WHERE telefone IS NOT NULL
+  AND telefone ~ '[^0-9]'; -- Apenas atualiza se contiver caracteres não-numéricos
+
+-- Comentário: Esta migração garante que todos os telefones sejam armazenados
+-- em formato numérico puro, facilitando validações e formatações no frontend.

--- a/src/main/resources/db/test/V3.13__Remove_Phone_Masks.sql
+++ b/src/main/resources/db/test/V3.13__Remove_Phone_Masks.sql
@@ -9,9 +9,9 @@
 
 -- Atualizar telefones do fornecedor removendo caracteres não-numéricos
 UPDATE fornecedor
-SET telefone = REGEXP_REPLACE(telefone, '[^0-9]', '', 'g')
+SET telefone = REGEXP_REPLACE(telefone, '[^0-9]', '')
 WHERE telefone IS NOT NULL
-  AND telefone ~ '[^0-9]'; -- Apenas atualiza se contiver caracteres não-numéricos
+  AND REGEXP_LIKE(telefone, '[^0-9]'); -- Apenas atualiza se contiver caracteres não-numéricos
 
 -- Comentário: Esta migração garante que todos os telefones sejam armazenados
 -- em formato numérico puro, facilitando validações e formatações no frontend.

--- a/src/main/resources/db/test/V3.13__Remove_Phone_Masks.sql
+++ b/src/main/resources/db/test/V3.13__Remove_Phone_Masks.sql
@@ -1,0 +1,17 @@
+-- Migration V3.13 - Remover máscaras de telefones
+--
+-- OBJETIVO: Remover caracteres especiais (parênteses, hífens, espaços) dos números de telefone
+-- armazenados na tabela fornecedor, mantendo apenas os dígitos numéricos.
+--
+-- EXEMPLO:
+--   Antes: (41) 3123-4567, (41)98765-4321, 41 3123 4567
+--   Depois: 4131234567, 41987654321, 4131234567
+
+-- Atualizar telefones do fornecedor removendo caracteres não-numéricos
+UPDATE fornecedor
+SET telefone = REGEXP_REPLACE(telefone, '[^0-9]', '', 'g')
+WHERE telefone IS NOT NULL
+  AND telefone ~ '[^0-9]'; -- Apenas atualiza se contiver caracteres não-numéricos
+
+-- Comentário: Esta migração garante que todos os telefones sejam armazenados
+-- em formato numérico puro, facilitando validações e formatações no frontend.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Padronização de números de telefone: removidos caracteres não numéricos (máscaras, parênteses, hífens, espaços) dos registros existentes, preservando apenas dígitos. Migração aplicada em testes e produção para melhorar consistência, compatibilidade e integridade dos dados de contato.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->