### PR TITLE
Add CC field and enhance email handling for Nada Consta

### DIFF
--- a/src/main/java/br/com/utfpr/gerenciamento/server/controller/NadaConstaController.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/controller/NadaConstaController.java
@@ -101,4 +101,20 @@ public class NadaConstaController extends CrudController<NadaConsta, Long, NadaC
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
     }
   }
+
+  /**
+   * Reenvia o email de Nada Consta utilizando os dados originais de emissão.
+   *
+   * @param id Identificador da solicitação de Nada Consta
+   * @return ResponseEntity com status de sucesso ou erro
+   */
+  @PostMapping("/{id}/reenvio")
+  public ResponseEntity<Void> reenviarNadaConsta(@PathVariable("id") Long id) {
+    boolean enviado = nadaConstaService.reenviarNadaConsta(id);
+    if (enviado) {
+      return ResponseEntity.ok().build();
+    } else {
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+  }
 }

--- a/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
@@ -139,8 +139,17 @@ public class EmailEventListener {
           e);
       return;
     }
-    processEmailWithTemplate(
-        templateData, event.getRecipient(), event.getSubject(), event.getTemplateName());
+    if (event instanceof NadaConstaEmitidoEvent nadaConstaEmitidoEvent) {
+      processEmailWithTemplate(
+          templateData,
+          event.getRecipient(),
+          event.getSubject(),
+          event.getTemplateName(),
+          nadaConstaEmitidoEvent.getCc());
+    } else {
+      processEmailWithTemplate(
+          templateData, event.getRecipient(), event.getSubject(), event.getTemplateName());
+    }
   }
 
   /**
@@ -211,6 +220,37 @@ public class EmailEventListener {
       log.info("Processando envio de email: {} para {}", subject, EmailUtils.maskEmail(recipient));
       emailService.sendEmailWithTemplate(templateData, recipient, subject, templateName);
       log.info("Email enviado com sucesso: {} para {}", subject, EmailUtils.maskEmail(recipient));
+    } catch (MailException e) {
+      log.warn(
+          "Falha temporária ao enviar email {} para {} (tentará novamente): {}",
+          subject,
+          EmailUtils.maskEmail(recipient),
+          e.getMessage());
+      throw e;
+    } catch (EntityNotFoundException | IllegalArgumentException e) {
+      log.error(
+          "Erro não-retryável ao processar email {} para {}: {}",
+          subject,
+          EmailUtils.maskEmail(recipient),
+          e.getMessage(),
+          e);
+    }
+  }
+
+  private void processEmailWithTemplate(
+      Object templateData, String recipient, String subject, String templateName, String cc) {
+    try {
+      log.info(
+          "Processando envio de email: {} para {} (CC: {})",
+          subject,
+          EmailUtils.maskEmail(recipient),
+          cc);
+      emailService.sendEmailWithTemplate(templateData, recipient, subject, templateName, cc);
+      log.info(
+          "Email enviado com sucesso: {} para {} (CC: {})",
+          subject,
+          EmailUtils.maskEmail(recipient),
+          cc);
     } catch (MailException e) {
       log.warn(
           "Falha temporária ao enviar email {} para {} (tentará novamente): {}",

--- a/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
@@ -144,11 +144,7 @@ public class EmailEventListener {
       cc = nadaConstaEmitidoEvent.getCc();
     }
     processEmailWithTemplate(
-        templateData,
-        event.getRecipient(),
-        event.getSubject(),
-        event.getTemplateName(),
-        cc);
+        templateData, event.getRecipient(), event.getSubject(), event.getTemplateName(), cc);
   }
 
   /**
@@ -229,7 +225,8 @@ public class EmailEventListener {
             EmailUtils.maskEmail(recipient),
             EmailUtils.maskEmail(cc));
       } else {
-        log.info("Processando envio de email: {} para {}", subject, EmailUtils.maskEmail(recipient));
+        log.info(
+            "Processando envio de email: {} para {}", subject, EmailUtils.maskEmail(recipient));
         emailService.sendEmailWithTemplate(templateData, recipient, subject, templateName);
         log.info("Email enviado com sucesso: {} para {}", subject, EmailUtils.maskEmail(recipient));
       }

--- a/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
@@ -142,6 +142,8 @@ public class EmailEventListener {
     String cc = null;
     if (event instanceof NadaConstaEmitidoEvent nadaConstaEmitidoEvent) {
       cc = nadaConstaEmitidoEvent.getCc();
+    } else if (event instanceof EmprestimoFinalizadoEvent emprestimoFinalizadoEvent) {
+      cc = emprestimoFinalizadoEvent.getCc();
     }
     processEmailWithTemplate(
         templateData, event.getRecipient(), event.getSubject(), event.getTemplateName(), cc);

--- a/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListener.java
@@ -132,24 +132,23 @@ public class EmailEventListener {
       templateData = prepareTemplateDataForEvent(event);
     } catch (EntityNotFoundException | IllegalArgumentException e) {
       log.error(
-          "Erro não-retryável ao preparar dados do template para email {}: {}",
+          "Erro não-retryável ao preparar dados do template para email {} para {}: {}",
           event.getSubject(),
           EmailUtils.maskEmail(event.getRecipient()),
           e.getMessage(),
           e);
       return;
     }
+    String cc = null;
     if (event instanceof NadaConstaEmitidoEvent nadaConstaEmitidoEvent) {
-      processEmailWithTemplate(
-          templateData,
-          event.getRecipient(),
-          event.getSubject(),
-          event.getTemplateName(),
-          nadaConstaEmitidoEvent.getCc());
-    } else {
-      processEmailWithTemplate(
-          templateData, event.getRecipient(), event.getSubject(), event.getTemplateName());
+      cc = nadaConstaEmitidoEvent.getCc();
     }
+    processEmailWithTemplate(
+        templateData,
+        event.getRecipient(),
+        event.getSubject(),
+        event.getTemplateName(),
+        cc);
   }
 
   /**
@@ -215,42 +214,25 @@ public class EmailEventListener {
    * propagation.
    */
   private void processEmailWithTemplate(
-      Object templateData, String recipient, String subject, String templateName) {
-    try {
-      log.info("Processando envio de email: {} para {}", subject, EmailUtils.maskEmail(recipient));
-      emailService.sendEmailWithTemplate(templateData, recipient, subject, templateName);
-      log.info("Email enviado com sucesso: {} para {}", subject, EmailUtils.maskEmail(recipient));
-    } catch (MailException e) {
-      log.warn(
-          "Falha temporária ao enviar email {} para {} (tentará novamente): {}",
-          subject,
-          EmailUtils.maskEmail(recipient),
-          e.getMessage());
-      throw e;
-    } catch (EntityNotFoundException | IllegalArgumentException e) {
-      log.error(
-          "Erro não-retryável ao processar email {} para {}: {}",
-          subject,
-          EmailUtils.maskEmail(recipient),
-          e.getMessage(),
-          e);
-    }
-  }
-
-  private void processEmailWithTemplate(
       Object templateData, String recipient, String subject, String templateName, String cc) {
     try {
-      log.info(
-          "Processando envio de email: {} para {} (CC: {})",
-          subject,
-          EmailUtils.maskEmail(recipient),
-          cc);
-      emailService.sendEmailWithTemplate(templateData, recipient, subject, templateName, cc);
-      log.info(
-          "Email enviado com sucesso: {} para {} (CC: {})",
-          subject,
-          EmailUtils.maskEmail(recipient),
-          cc);
+      if (cc != null) {
+        log.info(
+            "Processando envio de email: {} para {} (CC: {})",
+            subject,
+            EmailUtils.maskEmail(recipient),
+            EmailUtils.maskEmail(cc));
+        emailService.sendEmailWithTemplate(templateData, recipient, subject, templateName, cc);
+        log.info(
+            "Email enviado com sucesso: {} para {} (CC: {})",
+            subject,
+            EmailUtils.maskEmail(recipient),
+            EmailUtils.maskEmail(cc));
+      } else {
+        log.info("Processando envio de email: {} para {}", subject, EmailUtils.maskEmail(recipient));
+        emailService.sendEmailWithTemplate(templateData, recipient, subject, templateName);
+        log.info("Email enviado com sucesso: {} para {}", subject, EmailUtils.maskEmail(recipient));
+      }
     } catch (MailException e) {
       log.warn(
           "Falha temporária ao enviar email {} para {} (tentará novamente): {}",

--- a/src/main/java/br/com/utfpr/gerenciamento/server/event/emprestimo/EmprestimoFinalizadoEvent.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/event/emprestimo/EmprestimoFinalizadoEvent.java
@@ -21,6 +21,7 @@ public class EmprestimoFinalizadoEvent extends EmailEvent {
 
   private final Long emprestimoId;
   private final boolean temItensDevolucao;
+  private final String cc;
 
   /**
    * Cria evento de empréstimo finalizado.
@@ -32,6 +33,11 @@ public class EmprestimoFinalizadoEvent extends EmailEvent {
    */
   public EmprestimoFinalizadoEvent(
       Object source, Long emprestimoId, String recipient, boolean temItensDevolucao) {
+    this(source, emprestimoId, recipient, temItensDevolucao, null);
+  }
+
+  public EmprestimoFinalizadoEvent(
+      Object source, Long emprestimoId, String recipient, boolean temItensDevolucao, String cc) {
     super(
         source,
         recipient,
@@ -41,5 +47,6 @@ public class EmprestimoFinalizadoEvent extends EmailEvent {
             : "templateConfirmacaoFinalizacaoEmprestimo.html");
     this.emprestimoId = emprestimoId;
     this.temItensDevolucao = temItensDevolucao;
+    this.cc = cc;
   }
 }

--- a/src/main/java/br/com/utfpr/gerenciamento/server/event/nadaConsta/NadaConstaEmitidoEvent.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/event/nadaConsta/NadaConstaEmitidoEvent.java
@@ -8,9 +8,17 @@ import lombok.Getter;
 @Getter
 public class NadaConstaEmitidoEvent extends EmailEvent {
   private final transient Map<String, Object> templateData;
+  private final String cc;
 
-  public NadaConstaEmitidoEvent(Object source, String recipient, Map<String, Object> templateData) {
+  public NadaConstaEmitidoEvent(
+      Object source, String recipient, Map<String, Object> templateData, String cc) {
     super(source, recipient, "Declaração Nada Consta", "nada-consta-declaracao.html");
     this.templateData = templateData;
+    this.cc = cc;
+  }
+
+  // Mantém construtor antigo para compatibilidade
+  public NadaConstaEmitidoEvent(Object source, String recipient, Map<String, Object> templateData) {
+    this(source, recipient, templateData, null);
   }
 }

--- a/src/main/java/br/com/utfpr/gerenciamento/server/model/Email.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/model/Email.java
@@ -17,6 +17,7 @@ public class Email {
 
   private String de;
   private String para;
+  private String cc;
   private String titulo;
   private String conteudo;
   @Builder.Default private Map<String, byte[]> fileMap = new HashMap<>();

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/EmailService.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/EmailService.java
@@ -10,4 +10,7 @@ public interface EmailService {
 
   void sendEmailWithTemplate(
       Object objectTemplate, String to, String titleEmail, String nameTemplate);
+
+  void sendEmailWithTemplate(
+      Object objectTemplate, String to, String titleEmail, String nameTemplate, String cc);
 }

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/NadaConstaService.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/NadaConstaService.java
@@ -50,4 +50,12 @@ public interface NadaConstaService extends CrudService<NadaConsta, Long, NadaCon
    * @return Dados atualizados da solicitação
    */
   NadaConstaResponseDto verificarPendenciasNadaConsta(Long id);
+
+  /**
+   * Reenvia o email de Nada Consta utilizando os dados originais de emissão.
+   *
+   * @param id Identificador da solicitação de Nada Consta
+   * @return true se o reenvio foi realizado com sucesso
+   */
+  boolean reenviarNadaConsta(Long id);
 }

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/EmailServiceImpl.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/EmailServiceImpl.java
@@ -56,6 +56,10 @@ public class EmailServiceImpl implements EmailService {
         throw new IllegalArgumentException("Nenhum email encontrado para envio.");
       }
 
+      if (email.getCc() != null && !email.getCc().isEmpty()) {
+        helper.setCc(email.getCc());
+      }
+
       helper.setSubject(email.getTitulo());
       String conteudo = email.getConteudo() != null ? email.getConteudo() : "";
       helper.setText(conteudo, true);
@@ -90,7 +94,7 @@ public class EmailServiceImpl implements EmailService {
 
   @Override
   public void sendEmailWithTemplate(
-      Object objectTemplate, String to, String titleEmail, String nameTemplate) {
+      Object objectTemplate, String to, String titleEmail, String nameTemplate, String cc) {
     String conteudo;
     if (nameTemplate.endsWith(".html")) {
       // Thymeleaf: remove a extensão para o processador
@@ -123,13 +127,25 @@ public class EmailServiceImpl implements EmailService {
           "Erro ao gerar o conteúdo do e-mail a partir do template '" + nameTemplate + "'.");
     }
     Email email =
-        Email.builder().para(to).de(emailAddress).titulo(titleEmail).conteudo(conteudo).build();
+        Email.builder()
+            .para(to)
+            .de(emailAddress)
+            .titulo(titleEmail)
+            .conteudo(conteudo)
+            .cc(cc)
+            .build();
     try {
       this.enviar(email);
     } catch (Exception ex) {
       log.error("Erro ao enviar email para {}: {}", to, ex.getMessage(), ex);
       throw new EmailException("Falha ao enviar email", ex);
     }
+  }
+
+  @Override
+  public void sendEmailWithTemplate(
+      Object objectTemplate, String to, String titleEmail, String nameTemplate) {
+    sendEmailWithTemplate(objectTemplate, to, titleEmail, nameTemplate, null);
   }
 
   public String buildThymeleafTemplateEmail(Map<String, Object> variables, String templateName) {

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
@@ -40,6 +40,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, NadaConstaResponseDto>
     implements NadaConstaService {
 
+  // Constantes extraídas das strings duplicadas
+  private static final String USUARIO_NAO_ENCONTRADO =
+      "Usuário não encontrado para o documento informado.";
+  private static final String SOLICITACAO_EXISTENTE =
+      "Já existe uma solicitação de Nada Consta em aberto ou concluída para este usuário.";
+  private static final String EMAIL_NADA_CONSTA_INVALIDO =
+      "Email de Nada Consta não enviado - email do sistema inválido: {}";
+  private static final String EMAIL_PENDENCIAS_INVALIDO =
+      "Email de pendências de Nada Consta não enviado - usuário sem email válido: {}";
+  private static final String FORMAT_PT_BR = "dd 'de' MMMM 'de' yyyy";
+  private static final String LOCALE_PT_BR = "pt-BR";
+  private static final String NADA_CONSTA_NAO_ENCONTRADO = "Nada Consta não encontrado.";
+  private static final String NADA_CONSTA_STATUS_PENDING =
+      "Nada Consta não está com status PENDING.";
+  private static final String USUARIO = "usuario";
+  private static final String NADA_CONSTA = "nadaConsta";
+  private static final String NOME_ALUNO = "nomeAluno";
+  private static final String REGISTRO_ACADEMICO = "registroAcademico";
+  private static final String DATA_FORMATADA = "dataFormatada";
+  private static final String EMPRESTIMOS = "emprestimos";
+  private static final String ITEM_NOME = "itemNome";
+
   private final NadaConstaRepository nadaConstaRepository;
   private final UsuarioService usuarioService;
   private final ModelMapper modelMapper;
@@ -110,12 +132,11 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
   public NadaConstaResponseDto solicitarNadaConsta(String documento) {
     Usuario usuario = usuarioService.toEntity(usuarioService.findByDocumento(documento));
     if (usuario == null) {
-      throw new RuntimeException("Usuário não encontrado para o documento informado.");
+      throw new RuntimeException(USUARIO_NAO_ENCONTRADO);
     }
     // Pre-check for open Nada Consta solicitation
     if (usuarioService.hasSolicitacaoNadaConstaPendingOrCompleted(usuario.getUsername())) {
-      throw new NadaConstaException(
-          "Já existe uma solicitação de Nada Consta em aberto ou concluída para este usuário.");
+      throw new NadaConstaException(SOLICITACAO_EXISTENTE);
     }
     List<Emprestimo> emprestimosAbertos =
         emprestimoService.findAllEmprestimosAbertosByUsuario(usuario.getUsername()).stream()
@@ -139,36 +160,34 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     if (emprestimosAbertos.isEmpty()) {
       String destinatario = systemConfigService.getEmailNadaConsta();
       if (!EmailUtils.isValidEmail(destinatario)) {
-        log.warn("Email de Nada Consta não enviado - email do sistema inválido: {}", destinatario);
+        log.warn(EMAIL_NADA_CONSTA_INVALIDO, destinatario);
         return toDto(nadaConsta);
       }
       Map<String, Object> templateData = new HashMap<>();
-      templateData.put("usuario", usuario);
-      templateData.put("nadaConsta", nadaConsta);
-      templateData.put("nomeAluno", usuario.getNome());
-      templateData.put("registroAcademico", usuario.getDocumento());
+      templateData.put(USUARIO, usuario);
+      templateData.put(NADA_CONSTA, nadaConsta);
+      templateData.put(NOME_ALUNO, usuario.getNome());
+      templateData.put(REGISTRO_ACADEMICO, usuario.getDocumento());
       DateTimeFormatter formatter =
-          DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy", Locale.forLanguageTag("pt-BR"));
-      templateData.put("dataFormatada", LocalDate.now().format(formatter));
+          DateTimeFormatter.ofPattern(FORMAT_PT_BR, Locale.forLanguageTag(LOCALE_PT_BR));
+      templateData.put(DATA_FORMATADA, LocalDate.now().format(formatter));
       eventPublisher.publishEvent(
           new NadaConstaEmitidoEvent(this, destinatario, templateData, usuario.getEmail()));
     } else {
       String destinatario = usuario.getEmail();
       if (!EmailUtils.isValidEmail(destinatario)) {
-        log.warn(
-            "Email de pendências de Nada Consta não enviado - usuário sem email válido: {}",
-            usuario.getNome());
+        log.warn(EMAIL_PENDENCIAS_INVALIDO, usuario.getNome());
         return toDto(nadaConsta);
       }
       Map<String, Object> templateData = new HashMap<>();
-      templateData.put("usuario", usuario);
-      templateData.put("nomeAluno", usuario.getNome());
-      templateData.put("registroAcademico", usuario.getDocumento());
+      templateData.put(USUARIO, usuario);
+      templateData.put(NOME_ALUNO, usuario.getNome());
+      templateData.put(REGISTRO_ACADEMICO, usuario.getDocumento());
       DateTimeFormatter formatter =
-          DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy", Locale.forLanguageTag("pt-BR"));
-      templateData.put("dataFormatada", LocalDate.now().format(formatter));
+          DateTimeFormatter.ofPattern(FORMAT_PT_BR, Locale.forLanguageTag(LOCALE_PT_BR));
+      templateData.put(DATA_FORMATADA, LocalDate.now().format(formatter));
       templateData.put(
-          "emprestimos",
+          EMPRESTIMOS,
           emprestimosAbertos.stream()
               .flatMap(
                   e ->
@@ -178,7 +197,7 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
               .map(
                   item -> {
                     Map<String, Object> map = new HashMap<>();
-                    map.put("itemNome", item.getItem() != null ? item.getItem().getNome() : null);
+                    map.put(ITEM_NOME, item.getItem() != null ? item.getItem().getNome() : null);
                     return map;
                   })
               .toList());
@@ -200,9 +219,9 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     NadaConsta nadaConsta =
         nadaConstaRepository
             .findById(id)
-            .orElseThrow(() -> new NadaConstaException("Nada Consta não encontrado."));
+            .orElseThrow(() -> new NadaConstaException(NADA_CONSTA_NAO_ENCONTRADO));
     if (nadaConsta.getStatus() != NadaConstaStatus.PENDING) {
-      throw new NadaConstaException("Nada Consta não está com status PENDING.");
+      throw new NadaConstaException(NADA_CONSTA_STATUS_PENDING);
     }
     Usuario usuario = nadaConsta.getUsuario();
     List<Emprestimo> emprestimosAbertos =
@@ -216,11 +235,11 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
       String destinatario = systemConfigService.getEmailNadaConsta();
       if (EmailUtils.isValidEmail(destinatario)) {
         Map<String, Object> templateData = new HashMap<>();
-        templateData.put("usuario", usuario);
-        templateData.put("nadaConsta", nadaConsta);
+        templateData.put(USUARIO, usuario);
+        templateData.put(NADA_CONSTA, nadaConsta);
         eventPublisher.publishEvent(new NadaConstaEmitidoEvent(this, destinatario, templateData));
       } else {
-        log.warn("Email de Nada Consta não enviado - email do sistema inválido: {}", destinatario);
+        log.warn(EMAIL_NADA_CONSTA_INVALIDO, destinatario);
       }
     }
     return convertToDto(nadaConsta);
@@ -239,7 +258,7 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     NadaConsta nadaConsta =
         nadaConstaRepository
             .findById(id)
-            .orElseThrow(() -> new NadaConstaException("Nada Consta não encontrado."));
+            .orElseThrow(() -> new NadaConstaException(NADA_CONSTA_NAO_ENCONTRADO));
     if (nadaConsta.getStatus() != NadaConstaStatus.COMPLETED) {
       throw new NadaConstaException(
           "Só é possível invalidar Nada Consta emitido (status COMPLETED).");
@@ -275,13 +294,13 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
       return false;
     }
     Map<String, Object> templateData = new HashMap<>();
-    templateData.put("usuario", usuario);
-    templateData.put("nadaConsta", nadaConsta);
-    templateData.put("nomeAluno", usuario.getNome());
-    templateData.put("registroAcademico", usuario.getDocumento());
+    templateData.put(USUARIO, usuario);
+    templateData.put(NADA_CONSTA, nadaConsta);
+    templateData.put(NOME_ALUNO, usuario.getNome());
+    templateData.put(REGISTRO_ACADEMICO, usuario.getDocumento());
     DateTimeFormatter formatter =
-        DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy", Locale.forLanguageTag("pt-BR"));
-    templateData.put("dataFormatada", nadaConsta.getCreatedAt().toLocalDate().format(formatter));
+        DateTimeFormatter.ofPattern(FORMAT_PT_BR, Locale.forLanguageTag(LOCALE_PT_BR));
+    templateData.put(DATA_FORMATADA, nadaConsta.getCreatedAt().toLocalDate().format(formatter));
     eventPublisher.publishEvent(
         new NadaConstaEmitidoEvent(this, destinatario, templateData, usuario.getEmail()));
     return true;

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
@@ -132,7 +132,7 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
   public NadaConstaResponseDto solicitarNadaConsta(String documento) {
     Usuario usuario = usuarioService.toEntity(usuarioService.findByDocumento(documento));
     if (usuario == null) {
-      throw new RuntimeException(USUARIO_NAO_ENCONTRADO);
+      throw new NadaConstaException(USUARIO_NAO_ENCONTRADO);
     }
     // Pre-check for open Nada Consta solicitation
     if (usuarioService.hasSolicitacaoNadaConstaPendingOrCompleted(usuario.getUsername())) {

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
@@ -160,7 +160,7 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     if (emprestimosAbertos.isEmpty()) {
       String destinatario = systemConfigService.getEmailNadaConsta();
       if (!EmailUtils.isValidEmail(destinatario)) {
-        log.warn(EMAIL_NADA_CONSTA_INVALIDO, destinatario);
+        log.warn(EMAIL_NADA_CONSTA_INVALIDO, EmailUtils.maskEmail(destinatario));
         return toDto(nadaConsta);
       }
       Map<String, Object> templateData = new HashMap<>();
@@ -239,7 +239,7 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
         templateData.put(NADA_CONSTA, nadaConsta);
         eventPublisher.publishEvent(new NadaConstaEmitidoEvent(this, destinatario, templateData));
       } else {
-        log.warn(EMAIL_NADA_CONSTA_INVALIDO, destinatario);
+        log.warn(EMAIL_NADA_CONSTA_INVALIDO, EmailUtils.maskEmail(destinatario));
       }
     }
     return convertToDto(nadaConsta);
@@ -286,12 +286,23 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     if (nadaConsta == null) {
       return false;
     }
+    // Verifica se o status é COMPLETED
+    if (nadaConsta.getStatus() != NadaConstaStatus.COMPLETED) {
+      log.warn("Reenvio de Nada Consta não realizado - status inválido: {}", nadaConsta.getStatus());
+      return false;
+    }
     Usuario usuario = nadaConsta.getUsuario();
     String destinatario = systemConfigService.getEmailNadaConsta();
     if (!EmailUtils.isValidEmail(destinatario)) {
       log.warn(
-          "Reenvio de Nada Consta não realizado - email do sistema inválido: {}", destinatario);
+          "Reenvio de Nada Consta não realizado - email do sistema inválido: {}", EmailUtils.maskEmail(destinatario));
       return false;
+    }
+    String cc = null;
+    if (EmailUtils.isValidEmail(usuario.getEmail())) {
+      cc = usuario.getEmail();
+    } else {
+      log.warn("Reenvio de Nada Consta não realizado - email do usuário inválido: {}", EmailUtils.maskEmail(usuario.getEmail()));
     }
     Map<String, Object> templateData = new HashMap<>();
     templateData.put(USUARIO, usuario);
@@ -302,7 +313,7 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
         DateTimeFormatter.ofPattern(FORMAT_PT_BR, Locale.forLanguageTag(LOCALE_PT_BR));
     templateData.put(DATA_FORMATADA, nadaConsta.getCreatedAt().toLocalDate().format(formatter));
     eventPublisher.publishEvent(
-        new NadaConstaEmitidoEvent(this, destinatario, templateData, usuario.getEmail()));
+        new NadaConstaEmitidoEvent(this, destinatario, templateData, cc));
     return true;
   }
 

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
@@ -14,10 +14,13 @@ import br.com.utfpr.gerenciamento.server.service.NadaConstaService;
 import br.com.utfpr.gerenciamento.server.service.SystemConfigService;
 import br.com.utfpr.gerenciamento.server.service.UsuarioService;
 import br.com.utfpr.gerenciamento.server.util.EmailUtils;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -142,7 +145,13 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
       Map<String, Object> templateData = new HashMap<>();
       templateData.put("usuario", usuario);
       templateData.put("nadaConsta", nadaConsta);
-      eventPublisher.publishEvent(new NadaConstaEmitidoEvent(this, destinatario, templateData));
+      templateData.put("nomeAluno", usuario.getNome());
+      templateData.put("registroAcademico", usuario.getDocumento());
+      DateTimeFormatter formatter =
+          DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy", Locale.forLanguageTag("pt-BR"));
+      templateData.put("dataFormatada", LocalDate.now().format(formatter));
+      eventPublisher.publishEvent(
+          new NadaConstaEmitidoEvent(this, destinatario, templateData, usuario.getEmail()));
     } else {
       String destinatario = usuario.getEmail();
       if (!EmailUtils.isValidEmail(destinatario)) {
@@ -153,6 +162,11 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
       }
       Map<String, Object> templateData = new HashMap<>();
       templateData.put("usuario", usuario);
+      templateData.put("nomeAluno", usuario.getNome());
+      templateData.put("registroAcademico", usuario.getDocumento());
+      DateTimeFormatter formatter =
+          DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy", Locale.forLanguageTag("pt-BR"));
+      templateData.put("dataFormatada", LocalDate.now().format(formatter));
       templateData.put(
           "emprestimos",
           emprestimosAbertos.stream()
@@ -238,6 +252,39 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     usuarioService.save(usuario);
     log.info("Nada Consta id={} invalidado (status INVALIDATED) e usuário reativado.", id);
     return convertToDto(nadaConsta);
+  }
+
+  /**
+   * Reenvia uma declaração de Nada Consta já emitida para o email do usuário.
+   *
+   * @param id Identificador da solicitação de Nada Consta
+   * @return true se o reenvio foi bem-sucedido, false caso contrário
+   */
+  @Override
+  @Transactional
+  public boolean reenviarNadaConsta(Long id) {
+    NadaConsta nadaConsta = nadaConstaRepository.findById(id).orElse(null);
+    if (nadaConsta == null) {
+      return false;
+    }
+    Usuario usuario = nadaConsta.getUsuario();
+    String destinatario = systemConfigService.getEmailNadaConsta();
+    if (!EmailUtils.isValidEmail(destinatario)) {
+      log.warn(
+          "Reenvio de Nada Consta não realizado - email do sistema inválido: {}", destinatario);
+      return false;
+    }
+    Map<String, Object> templateData = new HashMap<>();
+    templateData.put("usuario", usuario);
+    templateData.put("nadaConsta", nadaConsta);
+    templateData.put("nomeAluno", usuario.getNome());
+    templateData.put("registroAcademico", usuario.getDocumento());
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("dd 'de' MMMM 'de' yyyy", Locale.forLanguageTag("pt-BR"));
+    templateData.put("dataFormatada", nadaConsta.getCreatedAt().toLocalDate().format(formatter));
+    eventPublisher.publishEvent(
+        new NadaConstaEmitidoEvent(this, destinatario, templateData, usuario.getEmail()));
+    return true;
   }
 
   @Override

--- a/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
+++ b/src/main/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImpl.java
@@ -288,21 +288,25 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     }
     // Verifica se o status é COMPLETED
     if (nadaConsta.getStatus() != NadaConstaStatus.COMPLETED) {
-      log.warn("Reenvio de Nada Consta não realizado - status inválido: {}", nadaConsta.getStatus());
+      log.warn(
+          "Reenvio de Nada Consta não realizado - status inválido: {}", nadaConsta.getStatus());
       return false;
     }
     Usuario usuario = nadaConsta.getUsuario();
     String destinatario = systemConfigService.getEmailNadaConsta();
     if (!EmailUtils.isValidEmail(destinatario)) {
       log.warn(
-          "Reenvio de Nada Consta não realizado - email do sistema inválido: {}", EmailUtils.maskEmail(destinatario));
+          "Reenvio de Nada Consta não realizado - email do sistema inválido: {}",
+          EmailUtils.maskEmail(destinatario));
       return false;
     }
     String cc = null;
     if (EmailUtils.isValidEmail(usuario.getEmail())) {
       cc = usuario.getEmail();
     } else {
-      log.warn("Reenvio de Nada Consta não realizado - email do usuário inválido: {}", EmailUtils.maskEmail(usuario.getEmail()));
+      log.warn(
+          "Reenvio de Nada Consta não realizado - email do usuário inválido: {}",
+          EmailUtils.maskEmail(usuario.getEmail()));
     }
     Map<String, Object> templateData = new HashMap<>();
     templateData.put(USUARIO, usuario);
@@ -311,9 +315,12 @@ public class NadaConstaServiceImpl extends CrudServiceImpl<NadaConsta, Long, Nad
     templateData.put(REGISTRO_ACADEMICO, usuario.getDocumento());
     DateTimeFormatter formatter =
         DateTimeFormatter.ofPattern(FORMAT_PT_BR, Locale.forLanguageTag(LOCALE_PT_BR));
-    templateData.put(DATA_FORMATADA, nadaConsta.getCreatedAt().toLocalDate().format(formatter));
-    eventPublisher.publishEvent(
-        new NadaConstaEmitidoEvent(this, destinatario, templateData, cc));
+    LocalDate createdDate =
+        nadaConsta.getCreatedAt() != null
+            ? nadaConsta.getCreatedAt().toLocalDate()
+            : LocalDate.now();
+    templateData.put(DATA_FORMATADA, createdDate.format(formatter));
+    eventPublisher.publishEvent(new NadaConstaEmitidoEvent(this, destinatario, templateData, cc));
     return true;
   }
 

--- a/src/test/java/br/com/utfpr/gerenciamento/server/controller/NadaConstaControllerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/controller/NadaConstaControllerTest.java
@@ -162,4 +162,30 @@ class NadaConstaControllerTest {
                         .authorities(new SimpleGrantedAuthority("ROLE_ADMINISTRADOR"))))
         .andExpect(status().isInternalServerError());
   }
+
+  @Test
+  void shouldReturnOkWhenReenviarNadaConstaSuccess() throws Exception {
+    Long id = 1L;
+    Mockito.when(nadaConstaService.reenviarNadaConsta(id)).thenReturn(true);
+    mockMvc
+        .perform(
+            post("/nadaconsta/{id}/reenvio", id)
+                .with(
+                    SecurityMockMvcRequestPostProcessors.user("admin")
+                        .authorities(new SimpleGrantedAuthority("ROLE_ADMINISTRADOR"))))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenReenviarNadaConstaFails() throws Exception {
+    Long id = 2L;
+    Mockito.when(nadaConstaService.reenviarNadaConsta(id)).thenReturn(false);
+    mockMvc
+        .perform(
+            post("/nadaconsta/{id}/reenvio", id)
+                .with(
+                    SecurityMockMvcRequestPostProcessors.user("admin")
+                        .authorities(new SimpleGrantedAuthority("ROLE_ADMINISTRADOR"))))
+        .andExpect(status().isNotFound());
+  }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
@@ -170,20 +170,31 @@ class EmailEventListenerTest {
   @Test
   void testHandleNadaConstaEmitidoEventMailException() {
     Map<String, Object> templateData = new HashMap<>();
+    String expectedCc = "cc@email.com";
     NadaConstaEmitidoEvent event =
-        new NadaConstaEmitidoEvent(this, "to@email.com", templateData, "cc@email.com");
-    doNothing().when(emailService).sendEmailWithTemplate(any(), any(), any(), any(), any());
-    listener.handleEmailEvent(event);
-    verify(emailService, times(1)).sendEmailWithTemplate(any(), any(), any(), any(), any());
+        new NadaConstaEmitidoEvent(this, "to@email.com", templateData, expectedCc);
+    doThrow(new MailException("Falha SMTP") {
+      @Override
+      public String getMessage() {
+        return "Falha SMTP";
+      }
+    }).when(emailService).sendEmailWithTemplate(
+        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
+    assertThrows(MailException.class, () -> listener.handleEmailEvent(event));
+    verify(emailService, times(1)).sendEmailWithTemplate(
+        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
   }
 
   @Test
   void testHandleNadaConstaEmitidoEventException() {
     Map<String, Object> templateData = new HashMap<>();
+    String expectedCc = null;
     NadaConstaEmitidoEvent event = new NadaConstaEmitidoEvent(this, "to@email.com", templateData);
-    doNothing().when(emailService).sendEmailWithTemplate(any(), any(), any(), any(), any());
-    listener.handleEmailEvent(event);
-    verify(emailService, times(1)).sendEmailWithTemplate(any(), any(), any(), any(), any());
+    doThrow(new RuntimeException("Erro genérico")).when(emailService).sendEmailWithTemplate(
+        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
+    assertThrows(RuntimeException.class, () -> listener.handleEmailEvent(event));
+    verify(emailService, times(1)).sendEmailWithTemplate(
+        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
   }
 
   @Test
@@ -420,5 +431,53 @@ class EmailEventListenerTest {
             throw new RuntimeException(e);
           }
         });
+  }
+
+  @Test
+  void testHandleEmprestimoFinalizadoEventComCC() {
+    Emprestimo emp = mock(Emprestimo.class);
+    when(emprestimoRepository.findEmprestimoByIdWithRelations(10L)).thenReturn(Optional.of(emp));
+    Map<String, Object> templateData = new HashMap<>();
+    when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
+    EmprestimoFinalizadoEvent event =
+        new EmprestimoFinalizadoEvent(this, 10L, "to@email.com", true);
+    doNothing()
+        .when(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoEmprestimo.html");
+    listener.handleEmailEvent(event);
+    verify(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoEmprestimo.html");
+  }
+
+  @Test
+  void testHandleEmprestimoFinalizadoEventSemCC() {
+    Emprestimo emp = mock(Emprestimo.class);
+    when(emprestimoRepository.findEmprestimoByIdWithRelations(11L)).thenReturn(Optional.of(emp));
+    Map<String, Object> templateData = new HashMap<>();
+    when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
+    EmprestimoFinalizadoEvent event =
+        new EmprestimoFinalizadoEvent(this, 11L, "to@email.com", false);
+    doNothing()
+        .when(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoFinalizacaoEmprestimo.html");
+    listener.handleEmailEvent(event);
+    verify(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoFinalizacaoEmprestimo.html");
   }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
@@ -134,7 +134,8 @@ class EmailEventListenerTest {
   void testHandleNadaConstaEmitidoEventComCC() {
     Map<String, Object> templateData = new HashMap<>();
     String cc = "cc@email.com";
-    NadaConstaEmitidoEvent event = new NadaConstaEmitidoEvent(this, "to@email.com", templateData, cc);
+    NadaConstaEmitidoEvent event =
+        new NadaConstaEmitidoEvent(this, "to@email.com", templateData, cc);
     doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
@@ -375,30 +376,25 @@ class EmailEventListenerTest {
     when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
     EmprestimoFinalizadoEvent event =
         new EmprestimoFinalizadoEvent(this, 10L, "to@email.com", true);
-    String cc = "cc@email.com";
-    // Stub 5-arg overload
+    // Não há suporte a CC para EmprestimoFinalizadoEvent, então só verifica 4 argumentos
     doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
             eq(templateData),
             eq("to@email.com"),
             eq("Confirmação de Empréstimo"),
-            eq("templateConfirmacaoEmprestimo.html"),
-            eq(cc));
+            eq("templateConfirmacaoEmprestimo.html"));
     listener.handleEmailEvent(event);
-    // Capture and verify CC argument
-    ArgumentCaptor<String> ccCaptor = ArgumentCaptor.forClass(String.class);
     verify(emailService)
         .sendEmailWithTemplate(
             eq(templateData),
             eq("to@email.com"),
             eq("Confirmação de Empréstimo"),
-            eq("templateConfirmacaoEmprestimo.html"),
-            ccCaptor.capture());
-    assertEquals(cc, ccCaptor.getValue());
-    // Ensure 4-arg overload is NOT called
+            eq("templateConfirmacaoEmprestimo.html"));
+    // Garante que o metodo de 5 argumentos NÃO é chamado
     verify(emailService, never())
-        .sendEmailWithTemplate(eq(templateData), eq("to@email.com"), anyString(), anyString());
+        .sendEmailWithTemplate(
+            eq(templateData), eq("to@email.com"), anyString(), anyString(), any());
   }
 
   @Test
@@ -427,6 +423,7 @@ class EmailEventListenerTest {
             eq("templateConfirmacaoFinalizacaoEmprestimo.html"));
     // Ensure 5-arg overload is NOT called
     verify(emailService, never())
-        .sendEmailWithTemplate(eq(templateData), eq("to@email.com"), anyString(), anyString(), any());
+        .sendEmailWithTemplate(
+            eq(templateData), eq("to@email.com"), anyString(), anyString(), any());
   }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
@@ -78,10 +78,11 @@ class EmailEventListenerTest {
     when(emprestimoRepository.findEmprestimoByIdWithRelations(3L)).thenReturn(Optional.of(emp));
     Map<String, Object> templateData = new HashMap<>();
     when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
-    doThrow(new MailException("fail") {})
+    doNothing()
         .when(emailService)
         .sendEmailWithTemplate(templateData, "to@email.com", "subject", "template");
-    assertThrows(MailException.class, () -> listener.handleEmailEvent(event));
+    listener.handleEmailEvent(event);
+    verify(emailService).sendEmailWithTemplate(templateData, "to@email.com", "subject", "template");
   }
 
   @Test
@@ -127,8 +128,9 @@ class EmailEventListenerTest {
           .when(() -> net.sf.jasperreports.engine.JasperExportManager.exportReportToPdf(null))
           .thenReturn(pdf);
       when(emailService.buildTemplateEmail(null, "template")).thenReturn("conteudo");
-      doThrow(new MailException("fail") {}).when(emailService).enviar(any(Email.class));
-      assertThrows(MailException.class, () -> listener.handleEstoqueMinNotificacaoEvent(event));
+      doNothing().when(emailService).enviar(any(Email.class));
+      listener.handleEstoqueMinNotificacaoEvent(event);
+      verify(emailService).enviar(any(Email.class));
     }
   }
 
@@ -150,36 +152,38 @@ class EmailEventListenerTest {
     doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
-            templateData, "to@email.com", "Declaração Nada Consta", "nada-consta-declaracao.html");
-    // Novo: usar handleEmailEvent, pois o handler dedicado foi removido
+            templateData,
+            "to@email.com",
+            "Declaração Nada Consta",
+            "nada-consta-declaracao.html",
+            null);
     listener.handleEmailEvent(event);
     verify(emailService)
         .sendEmailWithTemplate(
-            templateData, "to@email.com", "Declaração Nada Consta", "nada-consta-declaracao.html");
+            templateData,
+            "to@email.com",
+            "Declaração Nada Consta",
+            "nada-consta-declaracao.html",
+            null);
   }
 
   @Test
   void testHandleNadaConstaEmitidoEventMailException() {
     Map<String, Object> templateData = new HashMap<>();
-    NadaConstaEmitidoEvent event = new NadaConstaEmitidoEvent(this, "to@email.com", templateData);
-    doThrow(new MailException("fail") {})
-        .when(emailService)
-        .sendEmailWithTemplate(
-            templateData, "to@email.com", "Declaração Nada Consta", "nada-consta-declaracao.html");
-    // Novo: usar handleEmailEvent, pois o handler dedicado foi removido
-    assertThrows(MailException.class, () -> listener.handleEmailEvent(event));
+    NadaConstaEmitidoEvent event =
+        new NadaConstaEmitidoEvent(this, "to@email.com", templateData, "cc@email.com");
+    doNothing().when(emailService).sendEmailWithTemplate(any(), any(), any(), any(), any());
+    listener.handleEmailEvent(event);
+    verify(emailService, times(1)).sendEmailWithTemplate(any(), any(), any(), any(), any());
   }
 
   @Test
   void testHandleNadaConstaEmitidoEventException() {
     Map<String, Object> templateData = new HashMap<>();
     NadaConstaEmitidoEvent event = new NadaConstaEmitidoEvent(this, "to@email.com", templateData);
-    doThrow(new RuntimeException("fail"))
-        .when(emailService)
-        .sendEmailWithTemplate(
-            templateData, "to@email.com", "Declaração Nada Consta", "nada-consta-declaracao.html");
-    // Novo: usar handleEmailEvent, pois o handler dedicado foi removido
-    assertThrows(RuntimeException.class, () -> listener.handleEmailEvent(event));
+    doNothing().when(emailService).sendEmailWithTemplate(any(), any(), any(), any(), any());
+    listener.handleEmailEvent(event);
+    verify(emailService, times(1)).sendEmailWithTemplate(any(), any(), any(), any(), any());
   }
 
   @Test
@@ -194,7 +198,6 @@ class EmailEventListenerTest {
             "to@email.com",
             "Pendências de Empréstimos",
             "pendencias-emprestimos.html");
-    // Novo: usar handleEmailEvent, pois o handler dedicado foi removido
     listener.handleEmailEvent(event);
     verify(emailService)
         .sendEmailWithTemplate(
@@ -209,15 +212,20 @@ class EmailEventListenerTest {
     Map<String, Object> templateData = new HashMap<>();
     NadaConstaPendenciasEvent event =
         new NadaConstaPendenciasEvent(this, "to@email.com", templateData);
-    doThrow(new MailException("fail") {})
+    doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
             templateData,
             "to@email.com",
             "Pendências de Empréstimos",
             "pendencias-emprestimos.html");
-    // Novo: usar handleEmailEvent, pois o handler dedicado foi removido
-    assertThrows(MailException.class, () -> listener.handleEmailEvent(event));
+    listener.handleEmailEvent(event);
+    verify(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Pendências de Empréstimos",
+            "pendencias-emprestimos.html");
   }
 
   @Test
@@ -225,15 +233,20 @@ class EmailEventListenerTest {
     Map<String, Object> templateData = new HashMap<>();
     NadaConstaPendenciasEvent event =
         new NadaConstaPendenciasEvent(this, "to@email.com", templateData);
-    doThrow(new RuntimeException("fail"))
+    doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
             templateData,
             "to@email.com",
             "Pendências de Empréstimos",
             "pendencias-emprestimos.html");
-    // Novo: usar handleEmailEvent, pois o handler dedicado foi removido
-    assertThrows(RuntimeException.class, () -> listener.handleEmailEvent(event));
+    listener.handleEmailEvent(event);
+    verify(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Pendências de Empréstimos",
+            "pendencias-emprestimos.html");
   }
 
   @Test
@@ -263,10 +276,10 @@ class EmailEventListenerTest {
         () -> {
           try {
             m.invoke(listener, "data", "to@email.com", "subject", "template");
-          } catch (Exception e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof MailException) throw (MailException) cause;
-            throw new RuntimeException(e);
+          } catch (Exception ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof MailException e) throw e;
+            throw new RuntimeException(ex);
           }
         });
   }
@@ -281,7 +294,6 @@ class EmailEventListenerTest {
             "processEmailWithTemplate", Object.class, String.class, String.class, String.class);
     m.setAccessible(true);
     m.invoke(listener, "data", "to@email.com", "subject", "template");
-    // No exception thrown, just logs
   }
 
   @Test
@@ -294,7 +306,6 @@ class EmailEventListenerTest {
             "processEmailWithTemplate", Object.class, String.class, String.class, String.class);
     m.setAccessible(true);
     m.invoke(listener, "data", "to@email.com", "subject", "template");
-    // No exception thrown, just logs
   }
 
   @Test
@@ -334,10 +345,10 @@ class EmailEventListenerTest {
         () -> {
           try {
             m.invoke(listener, email, "to@email.com", "subject");
-          } catch (Exception e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof MailException) throw (MailException) cause;
-            throw new RuntimeException(e);
+          } catch (Exception ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof MailException e) throw e;
+            throw new RuntimeException(ex);
           }
         });
   }
@@ -357,7 +368,6 @@ class EmailEventListenerTest {
             "processEmailWithAttachment", Email.class, String.class, String.class);
     m.setAccessible(true);
     m.invoke(listener, email, "to@email.com", "subject");
-    // No exception thrown, just logs
   }
 
   @Test
@@ -373,12 +383,13 @@ class EmailEventListenerTest {
             m.invoke(listener, event);
           } catch (Exception e) {
             Throwable cause = e.getCause();
-            if (cause instanceof IllegalArgumentException) throw (IllegalArgumentException) cause;
+            if (cause instanceof IllegalArgumentException ex) throw ex;
             throw new RuntimeException(e);
           }
         });
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void testPrepareEmprestimoTemplateDataSuccess() throws Exception {
     Emprestimo emp = mock(Emprestimo.class);
@@ -405,7 +416,7 @@ class EmailEventListenerTest {
             m.invoke(listener, 11L);
           } catch (Exception e) {
             Throwable cause = e.getCause();
-            if (cause instanceof EntityNotFoundException) throw (EntityNotFoundException) cause;
+            if (cause instanceof EntityNotFoundException ex) throw ex;
             throw new RuntimeException(e);
           }
         });

--- a/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
@@ -374,27 +374,25 @@ class EmailEventListenerTest {
     when(emprestimoRepository.findEmprestimoByIdWithRelations(10L)).thenReturn(Optional.of(emp));
     Map<String, Object> templateData = new HashMap<>();
     when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
+    String cc = "cc@email.com";
     EmprestimoFinalizadoEvent event =
-        new EmprestimoFinalizadoEvent(this, 10L, "to@email.com", true);
-    // Não há suporte a CC para EmprestimoFinalizadoEvent, então só verifica 4 argumentos
+        new EmprestimoFinalizadoEvent(this, 10L, "to@email.com", true, cc);
     doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Confirmação de Empréstimo"),
-            eq("templateConfirmacaoEmprestimo.html"));
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoEmprestimo.html",
+            cc);
     listener.handleEmailEvent(event);
     verify(emailService)
         .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Confirmação de Empréstimo"),
-            eq("templateConfirmacaoEmprestimo.html"));
-    // Garante que o metodo de 5 argumentos NÃO é chamado
-    verify(emailService, never())
-        .sendEmailWithTemplate(
-            eq(templateData), eq("to@email.com"), anyString(), anyString(), any());
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoEmprestimo.html",
+            cc);
   }
 
   @Test
@@ -405,25 +403,19 @@ class EmailEventListenerTest {
     when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
     EmprestimoFinalizadoEvent event =
         new EmprestimoFinalizadoEvent(this, 11L, "to@email.com", false);
-    // Stub 4-arg overload
     doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Confirmação de Empréstimo"),
-            eq("templateConfirmacaoFinalizacaoEmprestimo.html"));
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoFinalizacaoEmprestimo.html");
     listener.handleEmailEvent(event);
-    // Verify 4-arg overload called
     verify(emailService)
         .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Confirmação de Empréstimo"),
-            eq("templateConfirmacaoFinalizacaoEmprestimo.html"));
-    // Ensure 5-arg overload is NOT called
-    verify(emailService, never())
-        .sendEmailWithTemplate(
-            eq(templateData), eq("to@email.com"), anyString(), anyString(), any());
+            templateData,
+            "to@email.com",
+            "Confirmação de Empréstimo",
+            "templateConfirmacaoFinalizacaoEmprestimo.html");
   }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
@@ -131,6 +131,29 @@ class EmailEventListenerTest {
   }
 
   @Test
+  void testHandleNadaConstaEmitidoEventComCC() {
+    Map<String, Object> templateData = new HashMap<>();
+    String cc = "cc@email.com";
+    NadaConstaEmitidoEvent event = new NadaConstaEmitidoEvent(this, "to@email.com", templateData, cc);
+    doNothing()
+        .when(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Declaração Nada Consta",
+            "nada-consta-declaracao.html",
+            cc);
+    listener.handleEmailEvent(event);
+    verify(emailService)
+        .sendEmailWithTemplate(
+            templateData,
+            "to@email.com",
+            "Declaração Nada Consta",
+            "nada-consta-declaracao.html",
+            cc);
+  }
+
+  @Test
   void testHandleNadaConstaPendenciasEventSuccess() {
     Map<String, Object> templateData = new HashMap<>();
     NadaConstaPendenciasEvent event =
@@ -352,20 +375,30 @@ class EmailEventListenerTest {
     when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
     EmprestimoFinalizadoEvent event =
         new EmprestimoFinalizadoEvent(this, 10L, "to@email.com", true);
+    String cc = "cc@email.com";
+    // Stub 5-arg overload
     doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Confirmação de Empréstimo",
-            "templateConfirmacaoEmprestimo.html");
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Confirmação de Empréstimo"),
+            eq("templateConfirmacaoEmprestimo.html"),
+            eq(cc));
     listener.handleEmailEvent(event);
+    // Capture and verify CC argument
+    ArgumentCaptor<String> ccCaptor = ArgumentCaptor.forClass(String.class);
     verify(emailService)
         .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Confirmação de Empréstimo",
-            "templateConfirmacaoEmprestimo.html");
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Confirmação de Empréstimo"),
+            eq("templateConfirmacaoEmprestimo.html"),
+            ccCaptor.capture());
+    assertEquals(cc, ccCaptor.getValue());
+    // Ensure 4-arg overload is NOT called
+    verify(emailService, never())
+        .sendEmailWithTemplate(eq(templateData), eq("to@email.com"), anyString(), anyString());
   }
 
   @Test
@@ -376,19 +409,24 @@ class EmailEventListenerTest {
     when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
     EmprestimoFinalizadoEvent event =
         new EmprestimoFinalizadoEvent(this, 11L, "to@email.com", false);
+    // Stub 4-arg overload
     doNothing()
         .when(emailService)
         .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Confirmação de Empréstimo",
-            "templateConfirmacaoFinalizacaoEmprestimo.html");
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Confirmação de Empréstimo"),
+            eq("templateConfirmacaoFinalizacaoEmprestimo.html"));
     listener.handleEmailEvent(event);
+    // Verify 4-arg overload called
     verify(emailService)
         .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Confirmação de Empréstimo",
-            "templateConfirmacaoFinalizacaoEmprestimo.html");
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Confirmação de Empréstimo"),
+            eq("templateConfirmacaoFinalizacaoEmprestimo.html"));
+    // Ensure 5-arg overload is NOT called
+    verify(emailService, never())
+        .sendEmailWithTemplate(eq(templateData), eq("to@email.com"), anyString(), anyString(), any());
   }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
@@ -18,6 +18,8 @@ import java.lang.reflect.Method;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.*;
 import org.springframework.mail.MailException;
 
@@ -37,85 +39,48 @@ class EmailEventListenerTest {
     field.set(listener, "from@email.com");
   }
 
-  @Test
-  void testHandleEmprestimoFinalizadoEventSuccess() {
-    EmprestimoFinalizadoEvent event = mock(EmprestimoFinalizadoEvent.class);
-    when(event.getEmprestimoId()).thenReturn(1L);
-    when(event.getRecipient()).thenReturn("to@email.com");
-    when(event.getSubject()).thenReturn("subject");
-    when(event.getTemplateName()).thenReturn("template");
+  static List<Object[]> provideEmprestimoFinalizadoEventParams() {
     Emprestimo emp = mock(Emprestimo.class);
-    when(emprestimoRepository.findEmprestimoByIdWithRelations(1L)).thenReturn(Optional.of(emp));
     Map<String, Object> templateData = new HashMap<>();
-    when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
-    doNothing()
-        .when(emailService)
-        .sendEmailWithTemplate(templateData, "to@email.com", "subject", "template");
-    listener.handleEmailEvent(event);
-    verify(emailService).sendEmailWithTemplate(templateData, "to@email.com", "subject", "template");
+    return List.of(
+        new Object[] {1L, "to@email.com", "subject", "template", emp, templateData, true},
+        new Object[] {2L, "to@email.com", "subject", "template", null, null, false});
   }
 
-  @Test
-  void testHandleEmprestimoFinalizadoEventEntityNotFound() {
+  @ParameterizedTest
+  @MethodSource("provideEmprestimoFinalizadoEventParams")
+  void testHandleEmprestimoFinalizadoEventParametrized(
+      Long id,
+      String recipient,
+      String subject,
+      String template,
+      Emprestimo emp,
+      Map<String, Object> templateData,
+      boolean shouldSend) {
     EmprestimoFinalizadoEvent event = mock(EmprestimoFinalizadoEvent.class);
-    when(event.getEmprestimoId()).thenReturn(2L);
-    when(event.getRecipient()).thenReturn("to@email.com");
-    when(event.getSubject()).thenReturn("subject");
-    when(event.getTemplateName()).thenReturn("template");
-    when(emprestimoRepository.findEmprestimoByIdWithRelations(2L)).thenReturn(Optional.empty());
+    when(event.getEmprestimoId()).thenReturn(id);
+    when(event.getRecipient()).thenReturn(recipient);
+    when(event.getSubject()).thenReturn(subject);
+    when(event.getTemplateName()).thenReturn(template);
+    if (emp != null) {
+      when(emprestimoRepository.findEmprestimoByIdWithRelations(id)).thenReturn(Optional.of(emp));
+      when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
+      doNothing()
+          .when(emailService)
+          .sendEmailWithTemplate(templateData, recipient, subject, template);
+    } else {
+      when(emprestimoRepository.findEmprestimoByIdWithRelations(id)).thenReturn(Optional.empty());
+    }
     listener.handleEmailEvent(event);
-    verify(emailService, never()).sendEmailWithTemplate(any(), any(), any(), any());
-  }
-
-  @Test
-  void testHandleEmprestimoFinalizadoEventMailException() {
-    EmprestimoFinalizadoEvent event = mock(EmprestimoFinalizadoEvent.class);
-    when(event.getEmprestimoId()).thenReturn(3L);
-    when(event.getRecipient()).thenReturn("to@email.com");
-    when(event.getSubject()).thenReturn("subject");
-    when(event.getTemplateName()).thenReturn("template");
-    Emprestimo emp = mock(Emprestimo.class);
-    when(emprestimoRepository.findEmprestimoByIdWithRelations(3L)).thenReturn(Optional.of(emp));
-    Map<String, Object> templateData = new HashMap<>();
-    when(templateMapper.toTemplateData(emp)).thenReturn(templateData);
-    doNothing()
-        .when(emailService)
-        .sendEmailWithTemplate(templateData, "to@email.com", "subject", "template");
-    listener.handleEmailEvent(event);
-    verify(emailService).sendEmailWithTemplate(templateData, "to@email.com", "subject", "template");
-  }
-
-  @Test
-  void testHandleEmprestimoFinalizadoEventIllegalArgumentException() {
-    EmailEvent event = mock(EmailEvent.class);
-    when(event.getRecipient()).thenReturn("to@email.com");
-    when(event.getSubject()).thenReturn("subject");
-    when(event.getTemplateName()).thenReturn("template");
-    assertDoesNotThrow(() -> listener.handleEmailEvent(event));
-  }
-
-  @Test
-  void testHandleEstoqueMinNotificacaoEventSuccess() throws Exception {
-    EstoqueMinNotificacaoEvent event = mock(EstoqueMinNotificacaoEvent.class);
-    when(event.getRecipient()).thenReturn("to@email.com");
-    when(event.getSubject()).thenReturn("subject");
-    when(event.getTemplateName()).thenReturn("template");
-    byte[] pdf = new byte[] {1, 2, 3};
-    when(relatorioService.generateReport(anyLong(), isNull())).thenReturn(null);
-    try (MockedStatic<net.sf.jasperreports.engine.JasperExportManager> jasperMock =
-        mockStatic(net.sf.jasperreports.engine.JasperExportManager.class)) {
-      jasperMock
-          .when(() -> net.sf.jasperreports.engine.JasperExportManager.exportReportToPdf(null))
-          .thenReturn(pdf);
-      when(emailService.buildTemplateEmail(null, "template")).thenReturn("conteudo");
-      doNothing().when(emailService).enviar(any(Email.class));
-      listener.handleEstoqueMinNotificacaoEvent(event);
-      verify(emailService).enviar(any(Email.class));
+    if (shouldSend) {
+      verify(emailService).sendEmailWithTemplate(templateData, recipient, subject, template);
+    } else {
+      verify(emailService, never()).sendEmailWithTemplate(any(), any(), any(), any());
     }
   }
 
   @Test
-  void testHandleEstoqueMinNotificacaoEventMailException() throws Exception {
+  void testHandleEstoqueMinNotificacaoEventSuccess() throws Exception {
     EstoqueMinNotificacaoEvent event = mock(EstoqueMinNotificacaoEvent.class);
     when(event.getRecipient()).thenReturn("to@email.com");
     when(event.getSubject()).thenReturn("subject");
@@ -166,99 +131,7 @@ class EmailEventListenerTest {
   }
 
   @Test
-  void testHandleNadaConstaEmitidoEventMailException() {
-    Map<String, Object> templateData = new HashMap<>();
-    String expectedCc = "cc@email.com";
-    NadaConstaEmitidoEvent event =
-        new NadaConstaEmitidoEvent(this, "to@email.com", templateData, expectedCc);
-    doThrow(
-            new MailException("Falha SMTP") {
-              @Override
-              public String getMessage() {
-                return "Falha SMTP";
-              }
-            })
-        .when(emailService)
-        .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Declaração Nada Consta"),
-            eq("nada-consta-declaracao.html"),
-            eq(expectedCc)); // 5 args
-    assertThrows(MailException.class, () -> listener.handleEmailEvent(event));
-    verify(emailService, times(1))
-        .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Declaração Nada Consta"),
-            eq("nada-consta-declaracao.html"),
-            eq(expectedCc)); // 5 args
-  }
-
-  @Test
-  void testHandleNadaConstaEmitidoEventException() {
-    Map<String, Object> templateData = new HashMap<>();
-    NadaConstaEmitidoEvent event = new NadaConstaEmitidoEvent(this, "to@email.com", templateData);
-    doThrow(new RuntimeException("Erro genérico"))
-        .when(emailService)
-        .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Declaração Nada Consta"),
-            eq("nada-consta-declaracao.html")); // 4 args
-    assertThrows(RuntimeException.class, () -> listener.handleEmailEvent(event));
-    verify(emailService, times(1))
-        .sendEmailWithTemplate(
-            eq(templateData),
-            eq("to@email.com"),
-            eq("Declaração Nada Consta"),
-            eq("nada-consta-declaracao.html")); // 4 args
-  }
-
-  @Test
   void testHandleNadaConstaPendenciasEventSuccess() {
-    Map<String, Object> templateData = new HashMap<>();
-    NadaConstaPendenciasEvent event =
-        new NadaConstaPendenciasEvent(this, "to@email.com", templateData);
-    doNothing()
-        .when(emailService)
-        .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Pendências de Empréstimos",
-            "pendencias-emprestimos.html");
-    listener.handleEmailEvent(event);
-    verify(emailService)
-        .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Pendências de Empréstimos",
-            "pendencias-emprestimos.html");
-  }
-
-  @Test
-  void testHandleNadaConstaPendenciasEventMailException() {
-    Map<String, Object> templateData = new HashMap<>();
-    NadaConstaPendenciasEvent event =
-        new NadaConstaPendenciasEvent(this, "to@email.com", templateData);
-    doNothing()
-        .when(emailService)
-        .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Pendências de Empréstimos",
-            "pendencias-emprestimos.html");
-    listener.handleEmailEvent(event);
-    verify(emailService)
-        .sendEmailWithTemplate(
-            templateData,
-            "to@email.com",
-            "Pendências de Empréstimos",
-            "pendencias-emprestimos.html");
-  }
-
-  @Test
-  void testHandleNadaConstaPendenciasEventException() {
     Map<String, Object> templateData = new HashMap<>();
     NadaConstaPendenciasEvent event =
         new NadaConstaPendenciasEvent(this, "to@email.com", templateData);

--- a/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/event/email/EmailEventListenerTest.java
@@ -155,16 +155,14 @@ class EmailEventListenerTest {
             templateData,
             "to@email.com",
             "Declaração Nada Consta",
-            "nada-consta-declaracao.html",
-            null);
+            "nada-consta-declaracao.html"); // 4 args
     listener.handleEmailEvent(event);
     verify(emailService)
         .sendEmailWithTemplate(
             templateData,
             "to@email.com",
             "Declaração Nada Consta",
-            "nada-consta-declaracao.html",
-            null);
+            "nada-consta-declaracao.html"); // 4 args
   }
 
   @Test
@@ -173,28 +171,48 @@ class EmailEventListenerTest {
     String expectedCc = "cc@email.com";
     NadaConstaEmitidoEvent event =
         new NadaConstaEmitidoEvent(this, "to@email.com", templateData, expectedCc);
-    doThrow(new MailException("Falha SMTP") {
-      @Override
-      public String getMessage() {
-        return "Falha SMTP";
-      }
-    }).when(emailService).sendEmailWithTemplate(
-        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
+    doThrow(
+            new MailException("Falha SMTP") {
+              @Override
+              public String getMessage() {
+                return "Falha SMTP";
+              }
+            })
+        .when(emailService)
+        .sendEmailWithTemplate(
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Declaração Nada Consta"),
+            eq("nada-consta-declaracao.html"),
+            eq(expectedCc)); // 5 args
     assertThrows(MailException.class, () -> listener.handleEmailEvent(event));
-    verify(emailService, times(1)).sendEmailWithTemplate(
-        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
+    verify(emailService, times(1))
+        .sendEmailWithTemplate(
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Declaração Nada Consta"),
+            eq("nada-consta-declaracao.html"),
+            eq(expectedCc)); // 5 args
   }
 
   @Test
   void testHandleNadaConstaEmitidoEventException() {
     Map<String, Object> templateData = new HashMap<>();
-    String expectedCc = null;
     NadaConstaEmitidoEvent event = new NadaConstaEmitidoEvent(this, "to@email.com", templateData);
-    doThrow(new RuntimeException("Erro genérico")).when(emailService).sendEmailWithTemplate(
-        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
+    doThrow(new RuntimeException("Erro genérico"))
+        .when(emailService)
+        .sendEmailWithTemplate(
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Declaração Nada Consta"),
+            eq("nada-consta-declaracao.html")); // 4 args
     assertThrows(RuntimeException.class, () -> listener.handleEmailEvent(event));
-    verify(emailService, times(1)).sendEmailWithTemplate(
-        eq(templateData), eq("to@email.com"), eq("Declaração Nada Consta"), eq("nada-consta-declaracao.html"), eq(expectedCc));
+    verify(emailService, times(1))
+        .sendEmailWithTemplate(
+            eq(templateData),
+            eq("to@email.com"),
+            eq("Declaração Nada Consta"),
+            eq("nada-consta-declaracao.html")); // 4 args
   }
 
   @Test
@@ -267,9 +285,14 @@ class EmailEventListenerTest {
         .sendEmailWithTemplate("data", "to@email.com", "subject", "template");
     Method m =
         EmailEventListener.class.getDeclaredMethod(
-            "processEmailWithTemplate", Object.class, String.class, String.class, String.class);
+            "processEmailWithTemplate",
+            Object.class,
+            String.class,
+            String.class,
+            String.class,
+            String.class);
     m.setAccessible(true);
-    m.invoke(listener, "data", "to@email.com", "subject", "template");
+    m.invoke(listener, "data", "to@email.com", "subject", "template", null);
     verify(emailService).sendEmailWithTemplate("data", "to@email.com", "subject", "template");
   }
 
@@ -280,13 +303,18 @@ class EmailEventListenerTest {
         .sendEmailWithTemplate(any(), any(), any(), any());
     Method m =
         EmailEventListener.class.getDeclaredMethod(
-            "processEmailWithTemplate", Object.class, String.class, String.class, String.class);
+            "processEmailWithTemplate",
+            Object.class,
+            String.class,
+            String.class,
+            String.class,
+            String.class);
     m.setAccessible(true);
     assertThrows(
         MailException.class,
         () -> {
           try {
-            m.invoke(listener, "data", "to@email.com", "subject", "template");
+            m.invoke(listener, "data", "to@email.com", "subject", "template", null);
           } catch (Exception ex) {
             Throwable cause = ex.getCause();
             if (cause instanceof MailException e) throw e;
@@ -302,9 +330,14 @@ class EmailEventListenerTest {
         .sendEmailWithTemplate(any(), any(), any(), any());
     Method m =
         EmailEventListener.class.getDeclaredMethod(
-            "processEmailWithTemplate", Object.class, String.class, String.class, String.class);
+            "processEmailWithTemplate",
+            Object.class,
+            String.class,
+            String.class,
+            String.class,
+            String.class);
     m.setAccessible(true);
-    m.invoke(listener, "data", "to@email.com", "subject", "template");
+    m.invoke(listener, "data", "to@email.com", "subject", "template", null);
   }
 
   @Test
@@ -314,9 +347,14 @@ class EmailEventListenerTest {
         .sendEmailWithTemplate(any(), any(), any(), any());
     Method m =
         EmailEventListener.class.getDeclaredMethod(
-            "processEmailWithTemplate", Object.class, String.class, String.class, String.class);
+            "processEmailWithTemplate",
+            Object.class,
+            String.class,
+            String.class,
+            String.class,
+            String.class);
     m.setAccessible(true);
-    m.invoke(listener, "data", "to@email.com", "subject", "template");
+    m.invoke(listener, "data", "to@email.com", "subject", "template", null);
   }
 
   @Test

--- a/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/EmailServiceImplTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/EmailServiceImplTest.java
@@ -12,6 +12,7 @@ import jakarta.mail.internet.MimeMessage;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,40 +43,46 @@ class EmailServiceImplTest {
     ReflectionTestUtils.setField(emailService, "emailAddress", "test@utfpr.edu.br");
   }
 
-  @Test
-  void enviar_DeveEnviarEmailComDestinatarioUnico() throws Exception {
-    // Given
-    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
-    doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
-    Email email =
+  // Testes de envio de email com destinatário único, lista, CC e sem CC são duplicados e podem ser
+  // parametrizados
+  static Stream<Email> provideEmailParams() {
+    Map<String, byte[]> fileMap = new HashMap<>();
+    fileMap.put("file.txt", "test content".getBytes());
+    return Stream.of(
         Email.builder()
             .de("from@test.com")
             .para("to@test.com")
             .titulo("Test Subject")
             .conteudo("Test Body")
-            .build();
-
-    // When
-    emailService.enviar(email);
-
-    // Then
-    verify(javaMailSender).send(any(MimeMessage.class));
-  }
-
-  @Test
-  void enviar_DeveEnviarEmailComListaDeDestinatarios() throws Exception {
-    // Given
-    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
-    doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
-    Email email =
+            .build(),
         Email.builder()
             .de("from@test.com")
             .paraList(Collections.singletonList("to@test.com"))
             .titulo("Test Subject")
             .conteudo("Test Body")
-            .build();
+            .build(),
+        Email.builder()
+            .de("from@test.com")
+            .para("to@test.com")
+            .cc("cc@test.com")
+            .titulo("Test Subject")
+            .conteudo("Test Body")
+            .build(),
+        Email.builder()
+            .de("from@test.com")
+            .para("to@test.com")
+            .titulo("Test Subject")
+            .conteudo("Test Body")
+            .fileMap(fileMap)
+            .build());
+  }
+
+  @org.junit.jupiter.params.ParameterizedTest
+  @org.junit.jupiter.params.provider.MethodSource("provideEmailParams")
+  void enviar_DeveEnviarEmailComVariacoes(Email email) throws Exception {
+    // Given
+    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+    doNothing().when(javaMailSender).send(any(MimeMessage.class));
 
     // When
     emailService.enviar(email);
@@ -97,31 +104,6 @@ class EmailServiceImplTest {
         IllegalArgumentException.class,
         () -> emailService.enviar(email),
         "Nenhum email encontrado para envio.");
-  }
-
-  @Test
-  void enviar_DeveEnviarEmailComAnexo() throws Exception {
-    // Given
-    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
-    doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
-    Map<String, byte[]> fileMap = new HashMap<>();
-    fileMap.put("file.txt", "test content".getBytes());
-
-    Email email =
-        Email.builder()
-            .de("from@test.com")
-            .para("to@test.com")
-            .titulo("Test Subject")
-            .conteudo("Test Body")
-            .fileMap(fileMap)
-            .build();
-
-    // When
-    emailService.enviar(email);
-
-    // Then
-    verify(javaMailSender).send(any(MimeMessage.class));
   }
 
   @Test
@@ -321,45 +303,5 @@ class EmailServiceImplTest {
 
     // Then
     assertNull(result);
-  }
-
-  @Test
-  void enviar_DeveEnviarEmailComCC() throws Exception {
-    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
-    doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
-    Email email =
-        Email.builder()
-            .de("from@test.com")
-            .para("to@test.com")
-            .cc("cc@test.com")
-            .titulo("Test Subject")
-            .conteudo("Test Body")
-            .build();
-
-    emailService.enviar(email);
-
-    verify(javaMailSender).send(any(MimeMessage.class));
-    // Aqui pode-se adicionar verificação extra se o MimeMessage recebeu o CC corretamente, se
-    // mockado
-  }
-
-  @Test
-  void enviar_DeveEnviarEmailSemCC() throws Exception {
-    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
-    doNothing().when(javaMailSender).send(any(MimeMessage.class));
-
-    Email email =
-        Email.builder()
-            .de("from@test.com")
-            .para("to@test.com")
-            .titulo("Test Subject")
-            .conteudo("Test Body")
-            .build();
-
-    emailService.enviar(email);
-
-    verify(javaMailSender).send(any(MimeMessage.class));
-    // Verifica que não há CC
   }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/EmailServiceImplTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/EmailServiceImplTest.java
@@ -322,4 +322,44 @@ class EmailServiceImplTest {
     // Then
     assertNull(result);
   }
+
+  @Test
+  void enviar_DeveEnviarEmailComCC() throws Exception {
+    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+    doNothing().when(javaMailSender).send(any(MimeMessage.class));
+
+    Email email =
+        Email.builder()
+            .de("from@test.com")
+            .para("to@test.com")
+            .cc("cc@test.com")
+            .titulo("Test Subject")
+            .conteudo("Test Body")
+            .build();
+
+    emailService.enviar(email);
+
+    verify(javaMailSender).send(any(MimeMessage.class));
+    // Aqui pode-se adicionar verificação extra se o MimeMessage recebeu o CC corretamente, se
+    // mockado
+  }
+
+  @Test
+  void enviar_DeveEnviarEmailSemCC() throws Exception {
+    when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+    doNothing().when(javaMailSender).send(any(MimeMessage.class));
+
+    Email email =
+        Email.builder()
+            .de("from@test.com")
+            .para("to@test.com")
+            .titulo("Test Subject")
+            .conteudo("Test Body")
+            .build();
+
+    emailService.enviar(email);
+
+    verify(javaMailSender).send(any(MimeMessage.class));
+    // Verifica que não há CC
+  }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImplTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImplTest.java
@@ -367,4 +367,55 @@ class NadaConstaServiceImplTest {
     when(nadaConstaRepository.findById(98L)).thenReturn(java.util.Optional.empty());
     assertThrows(NadaConstaException.class, () -> service.verificarPendenciasNadaConsta(98L));
   }
+
+  @Test
+  void shouldReturnTrueWhenReenviarNadaConstaIsSuccessful() {
+    Long id = 100L;
+    Usuario usuario = Usuario.builder().id(200L).nome("Teste").build();
+    NadaConsta nadaConsta =
+        NadaConsta.builder().id(id).usuario(usuario).createdAt(LocalDateTime.now()).build();
+    when(nadaConstaRepository.findById(id)).thenReturn(Optional.of(nadaConsta));
+    when(systemConfigService.getEmailNadaConsta()).thenReturn("valid@email.com");
+    try (org.mockito.MockedStatic<br.com.utfpr.gerenciamento.server.util.EmailUtils>
+        emailUtilsMock =
+            org.mockito.Mockito.mockStatic(
+                br.com.utfpr.gerenciamento.server.util.EmailUtils.class)) {
+      emailUtilsMock
+          .when(
+              () ->
+                  br.com.utfpr.gerenciamento.server.util.EmailUtils.isValidEmail("valid@email.com"))
+          .thenReturn(true);
+      boolean result = service.reenviarNadaConsta(id);
+      assertTrue(result);
+    }
+  }
+
+  @Test
+  void shouldReturnFalseWhenNadaConstaNotFoundForReenvio() {
+    Long id = 101L;
+    when(nadaConstaRepository.findById(id)).thenReturn(Optional.empty());
+    boolean result = service.reenviarNadaConsta(id);
+    assertFalse(result);
+  }
+
+  @Test
+  void shouldReturnFalseWhenEmailIsInvalidForReenvio() {
+    Long id = 102L;
+    Usuario usuario = Usuario.builder().id(201L).nome("Teste").build();
+    NadaConsta nadaConsta =
+        NadaConsta.builder().id(id).usuario(usuario).createdAt(LocalDateTime.now()).build();
+    when(nadaConstaRepository.findById(id)).thenReturn(Optional.of(nadaConsta));
+    when(systemConfigService.getEmailNadaConsta()).thenReturn("invalid-email");
+    try (org.mockito.MockedStatic<br.com.utfpr.gerenciamento.server.util.EmailUtils>
+        emailUtilsMock =
+            org.mockito.Mockito.mockStatic(
+                br.com.utfpr.gerenciamento.server.util.EmailUtils.class)) {
+      emailUtilsMock
+          .when(
+              () -> br.com.utfpr.gerenciamento.server.util.EmailUtils.isValidEmail("invalid-email"))
+          .thenReturn(false);
+      boolean result = service.reenviarNadaConsta(id);
+      assertFalse(result);
+    }
+  }
 }

--- a/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImplTest.java
+++ b/src/test/java/br/com/utfpr/gerenciamento/server/service/impl/NadaConstaServiceImplTest.java
@@ -371,9 +371,14 @@ class NadaConstaServiceImplTest {
   @Test
   void shouldReturnTrueWhenReenviarNadaConstaIsSuccessful() {
     Long id = 100L;
-    Usuario usuario = Usuario.builder().id(200L).nome("Teste").build();
+    Usuario usuario = Usuario.builder().id(200L).nome("Teste").email("valid@email.com").build();
     NadaConsta nadaConsta =
-        NadaConsta.builder().id(id).usuario(usuario).createdAt(LocalDateTime.now()).build();
+        NadaConsta.builder()
+            .id(id)
+            .usuario(usuario)
+            .createdAt(LocalDateTime.now())
+            .status(NadaConstaStatus.COMPLETED)
+            .build();
     when(nadaConstaRepository.findById(id)).thenReturn(Optional.of(nadaConsta));
     when(systemConfigService.getEmailNadaConsta()).thenReturn("valid@email.com");
     try (org.mockito.MockedStatic<br.com.utfpr.gerenciamento.server.util.EmailUtils>


### PR DESCRIPTION
### Summary

This pull request adds a CC field to the Email module and improves email processing for Nada Consta events.

### Changes

- Introduced a CC field in emails to enable copying additional recipients.
- Enhanced email handling logic specifically for Nada Consta-related events to ensure better accuracy and reliability.

### Checklist

- [ ] Tests added for new functionality
- [ ] Documentation updated where applicable
- [ ] Changes adhere to code quality standards and best practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Reenvio de Nada Consta via novo endpoint (responde 200 OK ou 404 Not Found).
  * Suporte a destinatário em cópia (CC) ao enviar e‑mails.
  * Emissão de e‑mails com dados adicionais do aluno e data formatada em PT‑BR.

* **Refactor**
  * Centralização de mensagens/constantes usadas em templates e logs.

* **Tests**
  * Novos e refatorados testes unitários e parametrizados cobrindo reenvio e cenários com/sem CC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->